### PR TITLE
Ensure FewShotOptimizer always uses max examples

### DIFF
--- a/FewShotOptimizer.py
+++ b/FewShotOptimizer.py
@@ -53,27 +53,30 @@ class FewShotOptimizer:
         AvailableExamples = self.TrainData.to_dict('records')
         
         for Iteration in range(self.MaxExamples):
+            if not AvailableExamples:
+                print("No more available examples to add.")
+                break
+
             print(f"\nIteration {Iteration + 1}/{self.MaxExamples}")
-            
+
             BestCandidate = None
-            BestCandidateAccuracy = BestAccuracy
-            
+            BestCandidateAccuracy = float('-inf')
+
             for Candidate in AvailableExamples:
                 TestExamples = self.BestExamples + [Candidate]
                 TestAccuracy = self.EvaluateWithExamples(TestExamples)
-                
+
                 if TestAccuracy > BestCandidateAccuracy:
                     BestCandidate = Candidate
                     BestCandidateAccuracy = TestAccuracy
-            
+
             if BestCandidate is None:
-                print(f"No improvement found. Stopping at {len(self.BestExamples)} examples.")
                 break
-            
+
             self.BestExamples.append(BestCandidate)
             AvailableExamples.remove(BestCandidate)
             BestAccuracy = BestCandidateAccuracy
-            
+
             print(f"Added example: {BestCandidate}")
             print(f"New accuracy: {BestAccuracy:.4f} (improvement: {BestAccuracy - self.BaselineAccuracy:.4f})")
         

--- a/main.py
+++ b/main.py
@@ -51,17 +51,19 @@ def Main() -> None:
     )
 
     print("\n--- Few-Shot Optimization ---")
+    MaxExamples = 5
     Optimizer = FewShotOptimizer(
         TrainData=TrainData,
         ValidateData=ValidateData,
         FeatureColumns=["Text"],
         LabelColumn=LabelColumn,
         BasePromptTemplate=PromptTemplate,
-        MaxExamples=5,
+        MaxExamples=MaxExamples,
         Client=Client
     )
-    
+
     BestExamples, OptimizedPrompt, FinalAccuracy = Optimizer.OptimizeGreedy()
+    print(f"Examples used: {len(BestExamples)} / {MaxExamples}")
     
     print(f"\nFinal Accuracy: {FinalAccuracy:.4f}")
     


### PR DESCRIPTION
## Summary
- continue greedy selection until reaching `MaxExamples`
- print count of final examples used in `main`