### PR TITLE
Fix placeholder formatting issue

### DIFF
--- a/EvaluatePrompt.py
+++ b/EvaluatePrompt.py
@@ -1,4 +1,5 @@
 import os
+import re
 import concurrent.futures
 from typing import Tuple
 import time
@@ -14,12 +15,16 @@ class EvaluatePrompt:
         self.DataFrame = DataFrame.copy()
         self.FeatureColumns = FeatureColumns
         self.LabelColumn = LabelColumn
-        self.PromptTemplate = PromptTemplate
+        self.PromptTemplate = self.SanitizePlaceholders(PromptTemplate)
         self.Client = Client or openai.AzureOpenAI(
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
             api_version=os.getenv("OPENAI_API_VERSION"),
         )
+
+    @staticmethod
+    def SanitizePlaceholders(Template: str) -> str:
+        return re.sub(r"{['\"]([^'\"]+)['\"]}", r"{\1}", Template)
 
     def _GenerateSinglePrediction(self, Args: Tuple[int, pd.Series, str, float]) -> Tuple[int, str]:
         Index, Row, ModelName, Temperature = Args

--- a/FewShotOptimizer.py
+++ b/FewShotOptimizer.py
@@ -12,7 +12,7 @@ class FewShotOptimizer:
         self.ValidateData = ValidateData.copy()
         self.FeatureColumns = FeatureColumns
         self.LabelColumn = LabelColumn
-        self.BasePromptTemplate = BasePromptTemplate
+        self.BasePromptTemplate = EvaluatePrompt.SanitizePlaceholders(BasePromptTemplate)
         self.MaxExamples = MaxExamples
         self.Client = Client or openai.AzureOpenAI(
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ def Main() -> None:
     load_dotenv()
 
     YamlPath = "OptimizedResults.yaml"
-    PromptTemplate = 'Transform this greeting: {Text}'
+    PromptTemplate = 'Transform this greeting: {"Text"}'
 
     # Define feature columns and label column for your dataset
     FeatureColumns = ["Text"]


### PR DESCRIPTION
## Summary
- sanitize quoted placeholders before formatting prompts
- apply sanitization for few-shot prompt optimizer
- update main example to show quoted placeholder handling

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847c8d8e6f483208313f054ec4b87c6