### PR TITLE
Add DataLoader class with schema validation and dataset split

### DIFF
--- a/DataLoader.py
+++ b/DataLoader.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from typing import List
+
+class DataLoader:
+    def __init__(self, DataFrame: pd.DataFrame, InputColumns, LabelColumn: str):
+        self.DataFrame = DataFrame
+        if isinstance(InputColumns, list):
+            self.InputColumns = InputColumns
+        else:
+            self.InputColumns = [InputColumns]
+        self.LabelColumn = LabelColumn
+        self.ValidateSchema()
+
+    def ValidateSchema(self) -> bool:
+        MissingColumns = [Col for Col in self.InputColumns + [self.LabelColumn] if Col not in self.DataFrame.columns]
+        if MissingColumns:
+            raise ValueError(f"The following columns are missing: {MissingColumns}")
+        return True
+
+    def SplitDataset(self, TestSize: float = 0.2, RandomState: int = 42, Shuffle: bool = True):
+        self.ValidateSchema()
+        X = self.DataFrame[self.InputColumns]
+        Y = self.DataFrame[self.LabelColumn]
+        XTrain, XTest, YTrain, YTest = train_test_split(X, Y, test_size=TestSize, random_state=RandomState, shuffle=Shuffle)
+        return XTrain, XTest, YTrain, YTest

--- a/UnitTests/test_data_loader.py
+++ b/UnitTests/test_data_loader.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+from DataLoader import DataLoader
+
+def TestValidateSchemaPasses():
+    Frame = pd.DataFrame({"A": [1], "B": [2], "Label": [0]})
+    Loader = DataLoader(Frame, ["A", "B"], "Label")
+    assert Loader.ValidateSchema()
+
+
+def TestValidateSchemaFails():
+    Frame = pd.DataFrame({"A": [1], "Label": [0]})
+    with pytest.raises(ValueError):
+        DataLoader(Frame, ["A", "B"], "Label")
+
+
+def TestSplitDatasetShapes():
+    Frame = pd.DataFrame({
+        "A": range(10),
+        "B": range(10),
+        "Label": [0,1]*5
+    })
+    Loader = DataLoader(Frame, ["A", "B"], "Label")
+    TrainX, TestX, TrainY, TestY = Loader.SplitDataset(TestSize=0.3, RandomState=42)
+    assert len(TrainX) == 7
+    assert len(TestX) == 3
+    assert len(TrainY) == 7
+    assert len(TestY) == 3

--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from DataLoader import DataLoader
+
+if __name__ == "__main__":
+    SampleData = pd.DataFrame({
+        "A": [1, 2, 3, 4, 5],
+        "B": [5, 4, 3, 2, 1],
+        "Label": [0, 1, 0, 1, 0]
+    })
+
+    Loader = DataLoader(SampleData, ["A", "B"], "Label")
+    TrainX, TestX, TrainY, TestY = Loader.SplitDataset(TestSize=0.4, RandomState=1)
+    print("TrainX shape:", TrainX.shape)
+    print("TestX shape:", TestX.shape)
+    print("TrainY shape:", TrainY.shape)
+    print("TestY shape:", TestY.shape)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_functions = Test*


### PR DESCRIPTION
## Summary
- implement **DataLoader** with schema validation and dataset splitting
- configure pytest to collect PascalCase tests
- add unit tests for DataLoader
- create example usage in `main.py`